### PR TITLE
Update request_url/2 so that Lastfm endpoint is not hard-coded.

### DIFF
--- a/lib/elixirfm.ex
+++ b/lib/elixirfm.ex
@@ -31,7 +31,8 @@ defmodule Elixirfm do
   end
 
   defp request_url(endpoint, opts) do
-    Enum.join([@api_root, "#{opts}/?method=", endpoint, "&api_key=", lastfm_key(), "&format=json"])
+    base_url = Application.get_env(:elixirfm, :lastfm_ws) || @api_root
+    Enum.join([base_url, "#{opts}/?method=", endpoint, "&api_key=", lastfm_key(), "&format=json"])
   end
 
   defp create_headers(), do: [{"Authorization", "Bearer #{lastfm_key()}"}]

--- a/lib/elixirfm/user.ex
+++ b/lib/elixirfm/user.ex
@@ -112,6 +112,6 @@ defmodule Elixirfm.User do
   """
   @spec get_recent_tracks(String.t(), [limit: non_neg_integer(), page: non_neg_integer(), extended_info: non_neg_integer()]) :: Elixirfm.response
   def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended_info: 0]) do
-    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended#{args[:extended_info]}")
+    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended_info]}")
   end
 end


### PR DESCRIPTION
Hey Joshua, 

Need this to bypass the live endpoint during [Bypass](https://github.com/PSPDFKit-labs/bypass) tests, e.g. see [this test](https://github.com/boonious/lastfm_archive/blob/f5f176ce6abe4cb241c490f201f1b01aca8379bc/test/extract_test.exs#L37) and the Bypass [function](https://github.com/boonious/lastfm_archive/blob/f5f176ce6abe4cb241c490f201f1b01aca8379bc/test/test_helper.exs#L6). 

Also found and fixed a missing `=` in the request string encoding of `User.get_recent_tracks/2`

Regards, 

Boon