### PR TITLE
get_recent_tracks: date range (to/from) retrieval, recursive request string encoding 

### DIFF
--- a/lib/elixirfm.ex
+++ b/lib/elixirfm.ex
@@ -31,7 +31,8 @@ defmodule Elixirfm do
   end
 
   defp request_url(endpoint, opts) do
-    Enum.join([@api_root, "#{opts}/?method=", endpoint, "&api_key=", lastfm_key(), "&format=json"])
+    base_url = Application.get_env(:elixirfm, :lastfm_ws) || @api_root
+    Enum.join([base_url, "#{opts}/?method=", endpoint, "&api_key=", lastfm_key(), "&format=json"])
   end
 
   defp create_headers(), do: [{"Authorization", "Bearer #{lastfm_key()}"}]

--- a/lib/elixirfm/user.ex
+++ b/lib/elixirfm/user.ex
@@ -119,8 +119,11 @@ defmodule Elixirfm.User do
 
   _to and from arguments not implemented yet_
   """
-  @spec get_recent_tracks(String.t(), [limit: non_neg_integer(), page: non_neg_integer(), extended_info: non_neg_integer()]) :: Elixirfm.response
-  def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended_info: 0]) do
-    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended_info]}")
+  @spec get_recent_tracks(String.t(), recent_track_args) :: Elixirfm.response
+  def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended_info: 0, to: 0, from: 0]) do
+    to = if args[:to] != 0, do: "&to=#{args[:to]}", else: ""
+    from = if args[:from] != 0, do: "&from=#{args[:from]}", else: ""
+    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended_info]}#{to}#{from}")
   end
+
 end

--- a/lib/elixirfm/user.ex
+++ b/lib/elixirfm/user.ex
@@ -121,9 +121,13 @@ defmodule Elixirfm.User do
   """
   @spec get_recent_tracks(String.t(), recent_track_args) :: Elixirfm.response
   def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended: 0, to: 0, from: 0]) do
-    to = if args[:to] != 0, do: "&to=#{args[:to]}", else: ""
-    from = if args[:from] != 0, do: "&from=#{args[:from]}", else: ""
-    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended]}#{to}#{from}")
+    ext_query_string = encode(args) |> Enum.join
+    uri(".getrecenttracks&user=#{query}#{ext_query_string}")
   end
+
+  defp encode(nil), do: ""
+  defp encode({_k, 0}), do: ""
+  defp encode({k, v}), do: "&#{k}=#{v}"
+  defp encode(args), do: for {k, v} <- args, do: encode({k, v})
 
 end

--- a/lib/elixirfm/user.ex
+++ b/lib/elixirfm/user.ex
@@ -112,6 +112,6 @@ defmodule Elixirfm.User do
   """
   @spec get_recent_tracks(String.t(), [limit: non_neg_integer(), page: non_neg_integer(), extended_info: non_neg_integer()]) :: Elixirfm.response
   def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended_info: 0]) do
-    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended#{args[:extended_info]}")
+    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended_info]}")
   end
 end

--- a/lib/elixirfm/user.ex
+++ b/lib/elixirfm/user.ex
@@ -2,6 +2,15 @@ defmodule Elixirfm.User do
   @moduledoc """
   Last.fm User Enpoints
   """
+
+  @type recent_track_arg :: {:limit, non_neg_integer()}
+                            | {:page, non_neg_integer()}
+                            | {:extended_info, non_neg_integer()}
+                            | {:to, non_neg_integer()}
+                            | {:from, non_neg_integer()}
+
+  @type recent_track_args :: [recent_track_arg]
+
   @method "user"
 
   defp uri(url), do: Elixirfm.get_request(@method <> url)

--- a/lib/elixirfm/user.ex
+++ b/lib/elixirfm/user.ex
@@ -5,7 +5,7 @@ defmodule Elixirfm.User do
 
   @type recent_track_arg :: {:limit, non_neg_integer()}
                             | {:page, non_neg_integer()}
-                            | {:extended_info, non_neg_integer()}
+                            | {:extended, non_neg_integer()}
                             | {:to, non_neg_integer()}
                             | {:from, non_neg_integer()}
 
@@ -115,15 +115,15 @@ defmodule Elixirfm.User do
   Get a list of the recent tracks listened to by this user.
   Also includes the currently playing track with the nowplaying="true" attribute if the user is currently listening.
 
-  ```extended_info``` argument accepts 1 or 0 as true or false
+  ```extended``` argument accepts 1 or 0 as true or false
 
   _to and from arguments not implemented yet_
   """
   @spec get_recent_tracks(String.t(), recent_track_args) :: Elixirfm.response
-  def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended_info: 0, to: 0, from: 0]) do
+  def get_recent_tracks(query, args \\ [limit: 20, page: 1, extended: 0, to: 0, from: 0]) do
     to = if args[:to] != 0, do: "&to=#{args[:to]}", else: ""
     from = if args[:from] != 0, do: "&from=#{args[:from]}", else: ""
-    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended_info]}#{to}#{from}")
+    uri(".getrecenttracks&user=#{query}&limit=#{args[:limit]}&page=#{args[:page]}&extended=#{args[:extended]}#{to}#{from}")
   end
 
 end


### PR DESCRIPTION
Hi Joshua, 

I have implemented the `to`, `from` parts of `get_recent_tracks` to enable date range retrieval and updated the function spec with a new type spec. Also refactored the function via generic / recursive request string encoding for the API keyword args.

Regards,

Boon